### PR TITLE
Allow video category

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,18 @@ See this [compenent in action](http://hackingbeauty.com/react-youtube-autocomple
 - Search Youtube based on text input
 - Retrieve list of results from Youtube
 - Display drop-down list of search results
+- Optionally limit results to specific category 
 
 ## Usage
 
 ```js
 <YoutubeAutocomplete
-  apiKey={string}        // you must get an API key from google if you want video search results returned
-  maxResults={string}    // defaults -> 50. Number of video search results you want
-  placeHolder={string}   // defaults -> "Search Youtube"
-  callback={function}    // callback to execute when search results are retrieved
-  className={string}     // defaults -> random string
+  apiKey={string}          // you must get an API key from google if you want video search results returned
+  maxResults={string}      // defaults -> 50. Number of video search results you want
+  placeHolder={string}     // defaults -> "Search Youtube"
+  videoCategoryId={string} // optional. The video category ID to limit the results to if specified
+  callback={function}      // callback to execute when search results are retrieved
+  className={string}       // defaults -> random string
 />
 ```
 
@@ -42,6 +44,7 @@ class Example extends React.Component {
       <YouTubeAutocomplete
         apiKey="YOUR-API-KEY-THAT-YOUR-REGISTERED-WITH-GOOGLE"
         placeHolder="Search Youtube"
+        videoCategoryId="10" //10 = Music, for example
         callback= this._onSearchResultsFound
       />
     );

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -135,9 +135,9 @@ const Demo = React.createClass({
           <br />
           <div id="demo-box">
             <Component
-      				apiKey='AIzaSyAtSE-0lZOKunNlkHt8wDJk9w4GjFL9Fu4'
-      				maxResults='20'
-      				callback={this.showResults}
+              apiKey='AIzaSyAtSE-0lZOKunNlkHt8wDJk9w4GjFL9Fu4'
+              maxResults='20'
+              callback={this.showResults}
               placeHolder='Search Youtube'
               className="my-class-name" />
           </div>

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -63,6 +63,7 @@ const componentEmbed = `
   <YoutubeAutocomplete
     apiKey='AIzaSyAtSE-0lZOKunNlkHt8wDJk9w4GjFL9Fu4'
     maxResults='20'
+    [videoCategoryId='10'] /* Optional. Limit results to given category */
     placeHolder='Search Youtube'
     callback={yourCallback} />
 `;
@@ -157,6 +158,11 @@ const Demo = React.createClass({
           <div className="code-snippet text-left">
             <Code embed={componentEmbed} />
           </div>
+          <br />
+          The <div className="code-snippet-inline">videoCateogoryId</div> parameter is optional. If specified, it will
+          limit the results to the category supplied. See the
+          <a href="https://developers.google.com/youtube/v3/docs/videoCategories/list">Youtube API</a> for more info on
+          the allowable values.
           <br />
           <br />
           <em>Step 3 - Download base styles</em>

--- a/demo/src/styles.scss
+++ b/demo/src/styles.scss
@@ -147,6 +147,11 @@ footer {
   padding: 10px;
 }
 
+.code-snippet-inline {
+  @extend .code-snippet;
+  display: inline-block;
+}
+
 #search-result-list {
   display: inline-block;
   padding-left:0px;

--- a/src/index.js
+++ b/src/index.js
@@ -69,6 +69,10 @@ class YoutubeAutocomplete extends Component {
         maxResults  : maxResults
       };
 
+      if(this.props.videoCategoryId) {
+        params.videoCategoryId = this.props.videoCategoryId;
+      }
+
     YoutubeClient.search(params, function(error,results){
       if(error) return console.log(error);
       self.props.callback(results.items);

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ class YoutubeAutocomplete extends Component {
         });
       }
     });
-	}
+    }
 
   onClick(event, optionData) {
     const searchTerm = optionData[0];
@@ -62,7 +62,7 @@ class YoutubeAutocomplete extends Component {
       searchTerm    = this.state.inputValue,
       maxResults    = this.props.maxResults <= 50 ? this.props.maxResults : '50',
       YoutubeClient = YoutubeFinder.createClient({ key: this.props.apiKey }),
-        params        = {
+      params        = {
         part        : 'id,snippet',
         type        : 'video',
         q           : searchTerm,
@@ -82,10 +82,10 @@ class YoutubeAutocomplete extends Component {
     // this is why you have to do onChange={this.handleChange.bind(this)}
     return <div>
       <Typeahead
-      	inputValue={this.state.inputValue}
-      	placeholder={this.props.placeHolder}
+        inputValue={this.state.inputValue}
+        placeholder={this.props.placeHolder}
         className={this.props.className}
-      	onChange={this.handleChange.bind(this)}
+        onChange={this.handleChange.bind(this)}
         optionTemplate={OptionsTemplate}
         options={this.state.options}
         onOptionClick={this.onClick.bind(this)}


### PR DESCRIPTION
I'm playing with React for the first time proper, and hacking together a little learning project. I needed a Youtube search, and found your component. But I wanted to limit the results to "music" videos specifically, so thought I would see if I can make it happen with your existing component.

The actual code change is simply line 72-74 in `onDropDownClose()`. The rest is just updating the demo and docs.

I'm not actually using this in  production project, so no need to merge it if you have any objections. It's was mostly for my entertainment and learning 😄 

Happy holidays! 🎅 